### PR TITLE
Respostas com keys atomizadas

### DIFF
--- a/lib/httpet/response.ex
+++ b/lib/httpet/response.ex
@@ -12,7 +12,7 @@ defmodule HTTPet.Response do
   defstruct @enforce_keys
 
   def handle(body: body, headers: headers, status_code: status_code) do
-    case Jason.decode(body) do
+    case Jason.decode(body, keys: :atoms) do
       {:ok, decoded_body} ->
         struct(__MODULE__,
           body: decoded_body,

--- a/test/httpet/response_test.exs
+++ b/test/httpet/response_test.exs
@@ -16,7 +16,7 @@ defmodule HTTPet.ResponseTest do
       valid_params = Map.to_list(@valid_params)
 
       assert %Response{
-               body: %{"json_valid" => "yes"},
+               body: %{json_valid: "yes"},
                headers: %{"Content-Type" => "application/json"},
                status_code: 299
              } = Response.handle(valid_params)

--- a/test/httpet_test.exs
+++ b/test/httpet_test.exs
@@ -28,7 +28,7 @@ defmodule HTTPetTest do
 
       assert {:ok,
               %Response{
-                body: %{"valid_json" => "yes"},
+                body: %{valid_json: "yes"},
                 headers: %{"Content-Type" => "application/json"},
                 status_code: 299
               }} == HTTPet.get(:fake_service, "uri/get")
@@ -47,7 +47,7 @@ defmodule HTTPetTest do
 
       assert {:ok,
               %Response{
-                body: %{"valid_json" => "yes"},
+                body: %{valid_json: "yes"},
                 headers: %{"Content-Type" => "application/json"},
                 status_code: 499
               }} == HTTPet.delete(:fake_service, "uri/delete")
@@ -69,7 +69,7 @@ defmodule HTTPetTest do
 
       assert {:ok,
               %Response{
-                body: %{"valid_json" => "yes"},
+                body: %{valid_json: "yes"},
                 headers: %{"Content-Type" => "application/json"},
                 status_code: 299
               }} == HTTPet.post(:fake_service, "uri/post", %{field: "value"})
@@ -91,7 +91,7 @@ defmodule HTTPetTest do
 
       assert {:ok,
               %Response{
-                body: %{"valid_json" => "yes"},
+                body: %{valid_json: "yes"},
                 headers: %{"Content-Type" => "application/json"},
                 status_code: 499
               }} == HTTPet.put(:fake_service, "uri/put", %{field: "value"})


### PR DESCRIPTION
## Motivação :muscle:
Atualmente a lib `Jason` está fazendo o decode do body das requisições numa struct com keys em forma de string. O [Middleware](https://hexdocs.pm/absinthe/Absinthe.Middleware.html#module-default-middleware) padrão não lida bem com elas, o ideal é usar keys como átomos.

## Solução :wrench:
- Fazer o decode com keys como átomos.

## Como testar :policeman:
```elixir
body = "{\"json_valid\":\"yes\"}"

Jason.decode(body)
{:ok, %{"json_valid" => "yes"}

Jason.decode(body, keys: :atoms)
{:ok, %{json_valid: "yes"}}
```