### PR TITLE
Creating Patch method to HTTPet

### DIFF
--- a/lib/httpet.ex
+++ b/lib/httpet.ex
@@ -30,6 +30,15 @@ defmodule HTTPet do
     end
   end
 
+  def patch(service, path, payload, headers \\ [], opts \\ []) do
+    url = ServiceUrl.build(service, path)
+    headers = RequestHeaders.add_defaults(headers)
+
+    with {:ok, payload} <- Jason.encode(payload) do
+      http_client().patch(url, payload, headers, merge_service_options(service, opts))
+    end
+  end
+
   def delete(service, path, headers \\ [], opts \\ []) do
     url = ServiceUrl.build(service, path)
     headers = RequestHeaders.add_defaults(headers)

--- a/lib/httpet/clients/client_behaviour.ex
+++ b/lib/httpet/clients/client_behaviour.ex
@@ -7,4 +7,5 @@ defmodule HTTPet.Clients.ClientBehaviour do
   @callback get(String.t(), list(), list()) :: {:ok, Response.t()} | {:error, any()}
   @callback post(String.t(), any(), list(), list()) :: {:ok, Response.t()} | {:error, any()}
   @callback put(String.t(), any(), list(), list()) :: {:ok, Response.t()} | {:error, any()}
+  @callback patch(String.t(), any(), list(), list()) :: {:ok, Response.t()} | {:error, any()}
 end

--- a/lib/httpet/clients/httpoison.ex
+++ b/lib/httpet/clients/httpoison.ex
@@ -34,6 +34,13 @@ defmodule HTTPet.Clients.HTTPoison do
     |> handle_response()
   end
 
+  @impl ClientBehaviour
+  def patch(url, body, headers, options) do
+    url
+    |> HTTPoison.patch(body, headers, options)
+    |> handle_response()
+  end
+
   defp handle_response(response) do
     case response do
       {:ok, %{body: body, headers: headers, status_code: status_code}} ->

--- a/test/httpet_test.exs
+++ b/test/httpet_test.exs
@@ -101,6 +101,28 @@ defmodule HTTPetTest do
               }} == HTTPet.put(:fake_service, "uri/put", %{field: "value"})
     end
 
+    test "patch/5 a successfull call via the HTTP client, returns a tuple with :ok and a %Response{} struct" do
+      ClientBehaviourMock
+      |> expect(:patch, 1, fn "http://0.0.0.0/uri/patch",
+                              "{\"field\":\"value\"}",
+                              @default_headers,
+                              [timeout: 50_000, recv_timeout: 50_000] ->
+        {:ok,
+         Response.handle(
+           body: "{\"valid_json\":\"yes\"}",
+           headers: %{"Content-Type" => "application/json"},
+           status_code: 202
+         )}
+      end)
+
+      assert {:ok,
+              %Response{
+                body: %{valid_json: "yes"},
+                headers: %{"Content-Type" => "application/json"},
+                status_code: 202
+              }} == HTTPet.patch(:fake_service, "uri/patch", %{field: "value"})
+    end
+
     test "put/5 a successfull call via the HTTP client, overrides service config via params" do
       ClientBehaviourMock
       |> expect(:put, 1, fn "http://0.0.0.0/uri/put",


### PR DESCRIPTION
Por conta das rotas de Patch da API de Payments (Wolverine), precisamos adicionar o Patch